### PR TITLE
37 feat 멋사 프론트엔드 8주차 과제

### DIFF
--- a/front/front_hw_w7/front_hw_w7/src/components/Comment.jsx
+++ b/front/front_hw_w7/front_hw_w7/src/components/Comment.jsx
@@ -2,6 +2,7 @@ import axios from "axios";
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
+const baseURL = import.meta.env.VITE_API_BASE_URL;
 
 const Comment = () => {
   const navigate = useNavigate();
@@ -9,7 +10,7 @@ const Comment = () => {
 
   const getComment = () => {
     axios
-      .get("http://127.0.0.1:8000/entries/")
+      .get(`${baseURL}/entries/`)
       .then((response) => {
         console.log(response);
         setComments(response.data);

--- a/front/front_seminar_w8/week08/src/Greeting.jsx
+++ b/front/front_seminar_w8/week08/src/Greeting.jsx
@@ -1,27 +1,34 @@
 import React, { useEffect, useState } from "react";
 
+// Greeting.jsx는 로컬스토리지에 저장된 access token을 이용해 카카오 API에서 사용자 정보를 가져와서, 사용자 이름과 프로필 이미지를 보여주는 컴포넌트
+
 const Greeting = () => {
-  const [name, setName] = useState();
-  const [profileImg, setProfileImg] = useState();
+  const [name, setName] = useState(); // 사용자 이름을 저장하는 상태 변수
+  const [profileImg, setProfileImg] = useState(); // 사용자 프로필 이미지를 저장하는 상태 변수
 
   useEffect(() => {
-    const accessToken = localStorage.getItem("accessToken");
+    // Redirection 컴포넌트에서 access token을 로컬 스토리지에 저장했었는데, 이제는 그 access token을 로컬스토리지에서 getItem()을 통해 가져와서 사용자 정보를 요청하는 데 사용
+    const accessToken = localStorage.getItem("accessToken"); // 로컬 스토리지에서 accessToken 가져와서 accessToken 변수에 저장
     fetch("https://kapi.kakao.com/v2/user/me", {
-      method: "GET",
+      //fetch 요청으로 사용자에 대한 정보를 요청
+      method: "GET", // 우리가 데이터(사용자 이름, 사용자 프로필 이미지)를 받아와야 하는 것이기 때문에 GET 방식으로 요청
       headers: {
-        Authorization: `Bearer ${accessToken}`,
+        Authorization: `Bearer ${accessToken}`, // 여기에 accessToken 값을 넣어서 어떤 사용자의 정보를 가져와야 하는지 카카오가 구별할 수 있도록 함
         "Content-type": "application/x-www-form-urlencoded",
       },
     }).then((res) => {
-      const userData = res.json();
+      // 사용자의 정보를 요청해서 응답을 받으면, 실행되는 구문
+      const userData = res.json(); // userData 변수에 응답 받은 데이터 JSON 형태로 저장
       userData.then((user) => {
-        setName(user.properties.nickname);
-        setProfileImg(user.properties.profile_image);
+        // JSON 형태로 파싱되기까지 시간이 걸리기 때문에, 파싱 완료되면 user 변수에 저장
+        setName(user.properties.nickname); // user 변수에서 properties 키에 해당하는 값의 nickname 키에 해당하는 값을 name 상태 변수에 저장
+        setProfileImg(user.properties.profile_image); // user 변수에서 properties 키에 해당하는 값의 profile_image 키에 해당하는 값을 name 상태 변수에 저장
       });
     });
   }, []);
 
   return (
+    // Greeting 컴포넌트가 실행되면, 사용자 이름과 프로필 사진을 보여줌
     <div>
       <div
         className="profile-image-div"

--- a/front/front_seminar_w8/week08/src/Greeting.jsx
+++ b/front/front_seminar_w8/week08/src/Greeting.jsx
@@ -14,7 +14,7 @@ const Greeting = () => {
       method: "GET", // 우리가 데이터(사용자 이름, 사용자 프로필 이미지)를 받아와야 하는 것이기 때문에 GET 방식으로 요청
       headers: {
         Authorization: `Bearer ${accessToken}`, // 여기에 accessToken 값을 넣어서 어떤 사용자의 정보를 가져와야 하는지 카카오가 구별할 수 있도록 함
-        "Content-type": "application/x-www-form-urlencoded",
+        "Content-type": "application/x-www-form-urlencoded", // 요청하는 데이터의 타입을 지정 (한 줄로 인코딩된 폼 데이터 형식)
       },
     }).then((res) => {
       // 사용자의 정보를 요청해서 응답을 받으면, 실행되는 구문

--- a/front/front_seminar_w8/week08/src/Login.jsx
+++ b/front/front_seminar_w8/week08/src/Login.jsx
@@ -12,20 +12,19 @@ const Login = () => {
 
   // 1. https://kauth.kakao.com/oauth/authorize? :카카오의 OAuth 인증 서버 주소
   // 2. response_type=code : 카카오에게 인가 코드 방식으로 로그인 할 것이라고 알려주는 부분
-  // 3. client_id= : 카카오 개발자 사이트에서 발급받은 REST API - 카카오가 어떤 앱의 요청을 했는지 알 수 있도록 해주는 부분 (Ex) CGV앱에서 카카오 로그인 요청) (환경변수로 지정)
-  // 4. redirect_uri= : 인가 코드를 리디렉션해줄 주소 (환경변수로 지정)
+  // 3. client_id= : 카카오 개발자 사이트에서 발급받은 REST API - 카카오가 어떤 앱의 요청을 했는지 알 수 있도록 해주는 부분 (Ex) CGV앱에서 카카오 로그인 요청) (.env 파일에서 환경변수로 지정)
+  // 4. redirect_uri= : 인가 코드를 리디렉션해줄 주소 (.env 파일에서 환경변수로 지정)
   const handleKakao = () => {
     window.location.href = authServerLink;
-  }; // handleKakao 함수가 실행되면, 카카오 인증 서버로 리다이렉트되어 인가 코드를 발급받을 수 있다.
+  }; // handleKakao 함수가 실행되면, 카카오 인증 서버(authServerLink)로 리다이렉트되어 인가 코드를 발급받을 수 있음
 
   return (
+    // 카카오 로그인 버튼에 클릭 이벤트 -> handleKakao 함수가 실행되도록 함
     <div className="login-box">
       <h1>로그인</h1>
       <div className="btn-container">
         <button onClick={handleKakao}>
           {" "}
-          // 카카오 로그인 버튼에 클릭 이벤트로 handleKakao 함수가 실행되도록
-          함.
           <img src={KakaoImg} alt="카카오 로그인" />
         </button>
         <button>

--- a/front/front_seminar_w8/week08/src/Login.jsx
+++ b/front/front_seminar_w8/week08/src/Login.jsx
@@ -2,20 +2,30 @@ import React from "react";
 import KakaoImg from "./assets/kakao_login.png";
 import GoogleImg from "./assets/google_login.png";
 
+// Login.jsx는 사용자가 '카카오 로그인' 버튼을 눌렀을 때, 카카오 인증서버로 리다이렉트시켜 인가코드를 발급받을 수 있도록 하는 컴포넌트
+
 const Login = () => {
-  const authServerLink = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${
+  const authServerLink = `https://kauth.kakao.com/oauth/authorize?
+  response_type=code&client_id=${
     import.meta.env.VITE_REST_API_KEY
   }&redirect_uri=${import.meta.env.VITE_REDIRECT_URI}`;
 
+  // 1. https://kauth.kakao.com/oauth/authorize? :카카오의 OAuth 인증 서버 주소
+  // 2. response_type=code : 카카오에게 인가 코드 방식으로 로그인 할 것이라고 알려주는 부분
+  // 3. client_id= : 카카오 개발자 사이트에서 발급받은 REST API - 카카오가 어떤 앱의 요청을 했는지 알 수 있도록 해주는 부분 (Ex) CGV앱에서 카카오 로그인 요청) (환경변수로 지정)
+  // 4. redirect_uri= : 인가 코드를 리디렉션해줄 주소 (환경변수로 지정)
   const handleKakao = () => {
     window.location.href = authServerLink;
-  };
+  }; // handleKakao 함수가 실행되면, 카카오 인증 서버로 리다이렉트되어 인가 코드를 발급받을 수 있다.
 
   return (
     <div className="login-box">
       <h1>로그인</h1>
       <div className="btn-container">
         <button onClick={handleKakao}>
+          {" "}
+          // 카카오 로그인 버튼에 클릭 이벤트로 handleKakao 함수가 실행되도록
+          함.
           <img src={KakaoImg} alt="카카오 로그인" />
         </button>
         <button>

--- a/front/front_seminar_w8/week08/src/Login.jsx
+++ b/front/front_seminar_w8/week08/src/Login.jsx
@@ -13,7 +13,7 @@ const Login = () => {
   // 1. https://kauth.kakao.com/oauth/authorize? :카카오의 OAuth 인증 서버 주소
   // 2. response_type=code : 카카오에게 인가 코드 방식으로 로그인 할 것이라고 알려주는 부분
   // 3. client_id= : 카카오 개발자 사이트에서 발급받은 REST API - 카카오가 어떤 앱의 요청을 했는지 알 수 있도록 해주는 부분 (Ex) CGV앱에서 카카오 로그인 요청) (.env 파일에서 환경변수로 지정)
-  // 4. redirect_uri= : 인가 코드를 리디렉션해줄 주소 (.env 파일에서 환경변수로 지정)
+  // 4. redirect_uri= : 코드를 받아서 처리한 후, 인가 코드를 리디렉션해줄 주소 (.env 파일에서 환경변수로 지정)
   const handleKakao = () => {
     window.location.href = authServerLink;
   }; // handleKakao 함수가 실행되면, 카카오 인증 서버(authServerLink)로 리다이렉트되어 인가 코드를 발급받을 수 있음

--- a/front/front_seminar_w8/week08/src/Redirection.jsx
+++ b/front/front_seminar_w8/week08/src/Redirection.jsx
@@ -20,7 +20,7 @@ const Redirection = () => {
         method: "POST", // 데이터 처리 방식: POST -> "데이터를 내가 보내겠다!" 라는 의미임. 우리는 인가 코드를 보내서 Access Token을 받고 싶은 것이기 때문에, POST 방식으로 요청
 
         headers: {
-          "Content-Type": "application/x-www-form-urlencoded",
+          "Content-Type": "application/x-www-form-urlencoded", // 요청하는 데이터의 타입을 지정 (한 줄로 인코딩된 폼 데이터 형식)
         },
       }
     ).then((res) => {

--- a/front/front_seminar_w8/week08/src/Redirection.jsx
+++ b/front/front_seminar_w8/week08/src/Redirection.jsx
@@ -1,12 +1,15 @@
 import React, { useEffect } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
+// Redirection.jsx는 (1) 사용자가 카카오 인증 서버에서 인가 코드를 발급받은 후, (2) 발급 받은 인가 코드를 이용해 access token을 발급받고, (3) 발급 받은 access token을 로컬 스토리지에 저장한 후, (4) Greeting 컴포넌트로 리다이렉트하는 컴포넌트
+
 const Redirection = () => {
   const [params] = useSearchParams();
+  // URL에서 인가 코드를 가져오기 위해 useSearchParams 사용 (?code=인증코드 <- 이런식으로 인가 코드가 URL에 포함되어 있음)
 
-  const authCode = params.get("code");
-  const grant_type = "authorization_code";
-  const navigate = useNavigate();
+  const authCode = params.get("code"); // params 배열에서 code 키에 해당하는 value값 (=인가코드)를 authCode 변수에 담음
+  const grant_type = "authorization_code"; // grand_type은 무슨 방식으로 토큰을 달라고 요청하는지 말해주는 값 (찾아보니 더 다양하게 있었다.) 근데 우리가 여기서 사용하는 방식은 'authorizaion_code' = 받은 인가 코드 사용해서 엑세스 토큰 받고 싶다는 뜻
+  const navigate = useNavigate(); // 특정 경로로 이동할 수 있게 하는 useNavigate 사용
 
   useEffect(() => {
     fetch(
@@ -14,22 +17,24 @@ const Redirection = () => {
         import.meta.env.VITE_REST_API_KEY
       }&redirect_uri=${import.meta.env.VITE_REDIRECT_URI}&code=${authCode}`,
       {
-        method: "POST",
+        method: "POST", // 데이터 처리 방식: POST -> "데이터를 내가 보내겠다!" 라는 의미임. 우리는 인가 코드를 보내서 Access Token을 받고 싶은 것이기 때문에, POST 방식으로 요청
 
         headers: {
           "Content-Type": "application/x-www-form-urlencoded",
         },
       }
     ).then((res) => {
-      const data = res.json();
+      // fetch 요청으로 데이터 보내고, 응답을 받으면 실행되는 구문, 받은 응답을 res 변수에 저장
+      const data = res.json(); // 받은 응답을 JSON 형태로 파싱하여 data 변수에 저장
       data.then((data) => {
-        localStorage.setItem("accessToken", data.access_token);
-        navigate("/greeting");
+        // JSON 형태로 파싱되는데에 시간이 걸리기 때문에, 파싱 완료되면 파싱된 데이터를 data 변수에 저장
+        localStorage.setItem("accessToken", data.access_token); // data에서 access_token 키에 해당하는 value(엑세스 토큰)dmf accessToken이라는 키로 로컬 스토리지에 저장
+        navigate("/greeting"); // 위 작업까지 완료되면, Greeting 컴포넌트로 이동
       });
     });
-  }, [authCode, grant_type, navigate]);
+  }, [authCode, grant_type, navigate]); // 배열 안에 있는 이 값들이 변경될 때마다 useEffect가 실행되도록 하는 부분! authCode, grant_type, navigate가 변경되면 다시 fetch 요청을 보내고, 위 과정 반복
 
-  return <div>Redirection Page: 카카오뱅크 로그인 중…</div>;
+  return <div>Redirection Page: 카카오뱅크 로그인 중…</div>; // Redirection 컴포넌트가 실행되면, "카카오뱅크 로그인 중…"이라는 문구가 뜨도록 함.
 };
 
 export default Redirection;


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#37 


## ✨ 과제 내용
### 세미나에서 작성한 코드에 주석으로 OAuth 2.0 흐름 설명하기 🦁

- 프론트엔드 8주차 세미나에서 작성한 코드가 OAuth 2.0 흐름에서 어떤 역할을 하고 있는지 주석을 추가하세요

### 🗂️ Login.jsx
<img width="683" height="532" alt="image" src="https://github.com/user-attachments/assets/7b04e158-7b8e-4fb3-89a3-6c514354087d" />

### 🗂️ Redirection.jsx
<img width="690" height="622" alt="image" src="https://github.com/user-attachments/assets/13fa5092-db98-49fb-a3ec-cddfdaa67511" />

### 🗂️ Greeting.jsx
<img width="679" height="641" alt="image" src="https://github.com/user-attachments/assets/d16406e6-973a-480f-8894-fe5759f06fb6" />

### 🗂️ App.jsx
<img width="461" height="310" alt="image" src="https://github.com/user-attachments/assets/c70de053-338c-4a84-9bed-f08e13cf04c0" />


## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
### 1️⃣ GET 방식에도 Content-Type이 필요한지?

- 처음엔 Content-Type에 대해서 공부하면서, `Content-Type: application/x-www-form-urlencoded` 은 서버에 보내는 데이터가 '한 줄로 인코깅된 폼 데이터 형식이다!" 라고 알려주는 부분이라고 이해했다. 
- 그래서 POST나 PUT처럼 뭔가 내가 데이터를 보낼 때만 붙이는 줄 알았는데, Greeting.jsx에서는 GET 방식인데도 "Content-Type": "application/x-www-form-urlencoded"를 넣는 코드가 있어서 혼란스러웠다. GET 방식에도 꼭 붙여야 하는 건지 헷갈려요..!

### 2️⃣ response_type 종류
- response_type 옵션이 무조건 'code'로만 쓰는 줄 알았는데, 찾아보니 생각보다 여러 옵션이 있다는 것을 알게 되었다.

`code` **: ⭐우리가 쓰는 방식⭐ 인가 코드를 먼저 받은 다음, 이 코드로 access token을 교환하는 방식**
`token` **: 인가 코드 없이, 로그인 성공하면 바로 acces token을 발급받는 방식**
`id_token` **: 사용자 인증 정보가 담긴 특별한 토큰 (JWT 형태)을 받는 것**

→ `response_type = code` 이 방식이 가장 안전하다고 하네요...

### 3️⃣ client_id같은 경우는 민감한 개인정보가 아닌데 왜 .env로 숨기고, gitignore로 추가하는지
- client_id가 그저 어떤 앱인지 식별하는 정도로만 사용되어 똑같다고 생각했다. (예를 들어서, 사용자 1, 사용자 2, 사용자 3이 모두 CGV앱에서 카카오 로그인 시도를 했다면, 셋 다 똑같은 Client_id 라고 생각) 
-  실제로 사용자 1,2,3의 client_id 자체는 `어떤 앱에서 요청했는지 식별하는 값`이라 여러 유저가 같은 앱에서 로그인하면 당연히 동일하다는 것은 확인하였다.

→ client_id는 민감한 개인정보 까지는 아니지만 서비스 무결성을 지키기 위한 보안정보로 다루는 게 일반적이라는 것까진 알게 되었다. (<- 정확히 이해한 것이 맞을까요?) 
→ 또 어떤 의견으로는 client_id가 노출되면, 👉🏻내 앱인 척👈🏻 하는 요청이 가능하다는데, client_id가 다 똑같으면 무슨 위험이 있는 건지 궁금했다..

### 4️⃣ Redirection.jsx, Greeting.jsx에서 fetch 후 json 파싱에서 then이 두 번 들어가는 이유?
<img width="623" height="341" alt="image" src="https://github.com/user-attachments/assets/27e83dbf-00e9-46b7-9865-d23018c4e911" />

1. fetch의 첫 번째 then
- fetch(URL)을 하게 되면, 서버에서 데이터를 받아오는 약속(Promise) 만드는 것
- 첫 번째 then은 서버로부터 응답이 왔을 때 실행

3. 두 번째 then
- res.json() 호출을 해야 위에서의 응답을 JSON 데이터로 파싱 가능!
- res.json()도 (1) 과정과 같이 바로 결과를 주는 함수가 아니고, "파싱 작업 끝나면 알려줄게"와 같이 또 다른 약속 준다고 함. (<- 데이터 파싱이 끝나면 그 데이터 받아서 사용하는 것) 

→ 내가 이해가 안됐던 부분은, json 데이터로 파싱하는 과정이 바로 이루어진다고 생각해서 '이것도 fetch 요청처럼 then을 써야 하나?' 라고 생각했던 것이다. 그런데, 이 과정에서도 바로 변환이 되는 것이 아니라, 이 과정 자체도 비동기(Promise)라서 then을 한 번 더 써야만 진짜 데이터 쓸 수 있다는 것을 이해했습니다..! 비동기에 대해서 제대로 이해하지 못하고 있었나 보네요..😅

### 5️⃣ params의 실제 내부 값 확인 방법
- Redirection.jsx에서 [params] 배열에서 'code' 키에 해당하는 value(=인가 코드)를 가져와서 authCode 변수에 저장하였다.
-  params 배열 내부는 어떤 값들로 구성되어 있는지 궁금해서 콘솔을 찍어보았다.. 그런데 params는 콘솔에 찍으면 함수 목록만 나오고 실제 key-value가 안 보였다.

→  params는 특별한 객체라서, 그냥 console.log로는 내부 값이 안 보이고, 다음과 같이 코드를 적어줘야 진짜 값이 보인다는 것을 알게 되었다.`console.log([...params.entries()]);` 
